### PR TITLE
feat: open projects in new tab

### DIFF
--- a/views/statusboard.ejs
+++ b/views/statusboard.ejs
@@ -54,7 +54,7 @@
     <% for (const project of projects) { %>
     <tr>
       <td class="name left" style="min-width: 170px">
-        <a href="<%= project.url %>">
+        <a href="<%= project.url %>" target="_blank">
           <%= project.name %>
         </a>
       </td>


### PR DESCRIPTION
This change resolves #16 by adding target="_blank" to the href to name column