### PR TITLE
fix: make popup fullscreen

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -65,21 +65,23 @@ nav .org img {
 #add-org-popup.opened {
   padding: 10px;
   display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: absolute;
-  width: 330px;
-  right: 50%;
-  bottom: 50%;
-  transform: translate(50%, 50%);
-  -webkit-box-shadow: 0px 0px 0px 9999px rgba(0, 0, 0, 0.5);
-  box-shadow: 0px 0px 0px 9999px rgba(0, 0, 0, 0.5);
-  background: white;
-  border-radius: 8px;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(20, 20, 20, 0.7);
+  z-index: 9;
+  box-sizing: border-box;
 }
 
-.popin-content {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+.popup-content {
+  display: block;
+  border-radius: 8px;
+  background: white;
+  padding: 10px;
+  width: 330px;
 }
 
 .popup-title {
@@ -87,6 +89,12 @@ nav .org img {
   font-weight: bold;
   flex: 1;
   margin-bottom: 15px;
+}
+
+.popup-form-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #add-org-btn {

--- a/public/index.html
+++ b/public/index.html
@@ -26,17 +26,19 @@
   <nav id="orgs"></nav>
 
   <div id="add-org-popup">
-    <p class="popup-title">Add an organization (Github only)</p>
-    <form id="add-org-form" class="popin-content"action="">
-      <input type="text" placeholder="NodeSecure" id="add-org-input">
-      <button id="add-org-btn">
-        <span id="popup-loader" class="lds-dual-ring hidden"></span>
-        Add
-      </button>
-      <button id="close-popup" type="button">
-        Cancel
-      </button>
-    </form>
+    <div class="popup-content">
+      <p class="popup-title">Add an organization (Github only)</p>
+      <form id="add-org-form" class="popup-form-content" action="">
+        <input type="text" placeholder="NodeSecure" id="add-org-input">
+        <button id="add-org-btn">
+          <span id="popup-loader" class="lds-dual-ring hidden"></span>
+          Add
+        </button>
+        <button id="close-popup" type="button">
+          Cancel
+        </button>
+      </form>
+    </div>
   </div>
 
   <!-- EJS generated server side -->


### PR DESCRIPTION
This PR fixes 2 things:
- design: the menu button looks active when the popup is opened
- menu button & inputs are now "disabled" (the popup background is just over the whole page)
![popupfail](https://github.com/dashlog/web-ui/assets/39910767/1704f30d-f709-4cb8-b4e4-b7f4cf983ae8)
